### PR TITLE
Add unique index to prevent duplicate course module completion records.

### DIFF
--- a/progress/migrations/0002_add_unique_index.py
+++ b/progress/migrations/0002_add_unique_index.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import model_utils.fields
+from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+import django.utils.timezone
+from django.conf import settings
+
+
+def reduce_duplicates(apps, schema_editor):
+    """
+    This will delete duplicate entries using a large number of small queries.
+
+    This will help prevent blocking other access to the database.  There is a 
+    race condition where new duplicates may be created while removing the first
+    set of duplicates.  This is unavoidable, so the ADD UNIQUE INDEX operation 
+    is written to expect and remove duplicates.  This operation is designed only 
+    to reduce the amount of time the table will be locked.
+    """
+
+    CourseModuleCompletion = apps.get_model('progress', 'CourseModuleCompletion')
+    tasks = CourseModuleCompletion.objects.values('course_id', 'content_id', 'user_id')
+    tasks = tasks.annotate(count=models.Count('pk'), min_pk=models.Min('pk'))
+
+    for task in tasks:
+        if task['count'] > 1:
+            qs = CourseModuleCompletion.objects.filter(
+                user_id=task['user_id'],
+                course_id=task['course_id'],
+                content_id=task['content_id'],
+            )
+            qs = qs.exclude(pk=task['min_pk'])
+            qs.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('progress', '0001_initial')
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=reduce_duplicates,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RunSQL(
+            sql="ALTER IGNORE TABLE progress_coursemodulecompletion ADD UNIQUE INDEX course_content_user_uniq (course_id, content_id, user_id);",
+            reverse_sql="ALTER TABLE progress_coursemodulecompletion DROP INDEX course_content_user_uniq;",
+            state_operations=[
+                migrations.AlterUniqueTogether(
+                    name='coursemodulecompletion',
+                    unique_together=set([('course_id', 'content_id', 'user')]),
+                ),
+            ],
+        ),
+    ]
+

--- a/progress/models.py
+++ b/progress/models.py
@@ -163,6 +163,9 @@ class CourseModuleCompletion(TimeStampedModel):
     content_id = models.CharField(max_length=255, db_index=True)
     stage = models.CharField(max_length=255, null=True, blank=True)
 
+    class Meta(object):
+        unique_together = ('course_id', 'content_id', 'user')
+
     @classmethod
     def get_actual_completions(cls):
         """


### PR DESCRIPTION
Duplicate records are being created where unique records are expected, due to race conditions that were previously unlikely.  They are causing 500 errors in later queries that expected unique values.

**JIRA tickets**: MCKIN-6284, OC-3258

**Discussions**: Provided upon request.

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: Upon request

**Merge deadline**: ASAP

**Testing instructions**:

1.  Run migration against stage environment with duplicate records.
2.  Verify that:
    1.  the progress_coursemodulecompletion table is not locked for long periods of time (ADD UNIQUE INDEX lock is unavoidable, but should be minimized by the `RunPython()` operation, which should only take short locks on the table.  If the time to add the index is unacceptably long, I would appreciate suggestions of alternative strategies to perform this migration.
    2.  the index is added without error.
    3.  the migration can be unapplied.
    4. the migration leaves one copy of each duplicate record.

**Author notes and concerns**:

As mentioned above, we have tried to minimize excessive table locking.  This is a large table, so it may still be an issue. If so, I would appreciate hearing alternative migration strategies.

**Reviewers**
- [ ] @bradenmacdonald 
- [ ] edx-devops TBD

**Settings**

N/A